### PR TITLE
ci: auto-deploy docs on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       environment:
@@ -36,4 +39,4 @@ jobs:
       - name: Build and Deploy
         run: |
           npx yarn build
-          GIT_USER=cupOJoseph npx yarn deploy 
+          GIT_USER=cupOJoseph npx yarn deploy


### PR DESCRIPTION
Adds push trigger on main branch so docs redeploy automatically on every merge. Manual dispatch still available.